### PR TITLE
Add a KSP-AVC version file

### DIFF
--- a/GameData/Tantares/Tantares.version
+++ b/GameData/Tantares/Tantares.version
@@ -1,0 +1,1 @@
+{"NAME":"Tantares","URL":"http://ksp-avc.cybutek.net/version.php?id=461","DOWNLOAD":"https://github.com/Tantares/Tantares","VERSION":{"MAJOR":3,"MINOR":0,"PATCH":0,"BUILD":0},"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":2}}

--- a/GameData/Tantares/Tantares.version
+++ b/GameData/Tantares/Tantares.version
@@ -1,1 +1,1 @@
-{"NAME":"Tantares","URL":"http://ksp-avc.cybutek.net/version.php?id=461","DOWNLOAD":"https://github.com/Tantares/Tantares/releases/","VERSION":{"MAJOR":3,"MINOR":0,"PATCH":0,"BUILD":0},"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":2}}
+{"NAME":"Tantares","URL":"http://ksp-avc.cybutek.net/version.php?id=461","DOWNLOAD":"https://github.com/Tantares/Tantares/releases/","VERSION":{"MAJOR":4,"MINOR":0,"PATCH":0,"BUILD":0},"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":2}}

--- a/GameData/Tantares/Tantares.version
+++ b/GameData/Tantares/Tantares.version
@@ -1,1 +1,1 @@
-{"NAME":"Tantares","URL":"http://ksp-avc.cybutek.net/version.php?id=461","DOWNLOAD":"https://github.com/Tantares/Tantares","VERSION":{"MAJOR":3,"MINOR":0,"PATCH":0,"BUILD":0},"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":2}}
+{"NAME":"Tantares","URL":"http://ksp-avc.cybutek.net/version.php?id=461","DOWNLOAD":"https://github.com/Tantares/Tantares/releases/","VERSION":{"MAJOR":3,"MINOR":0,"PATCH":0,"BUILD":0},"KSP_VERSION":{"MAJOR":1,"MINOR":2,"PATCH":2}}


### PR DESCRIPTION
This will appear in KSP-AVC (version checker) on a user’s computer. It’ll tell them when there is a new version (given that the file is updated).

I’ve taken the liberty to create a version file at http://ksp-avc.cybutek.net/. I’ll keep that in sync with what you have here on GitHub. If you want to take over said version let me know.