### PR TITLE
USI Life Support patch

### DIFF
--- a/GameData/Tantares/Patches/USI_LifeSupport/Acamar_Lab_1.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Acamar_Lab_1.cfg
@@ -1,0 +1,59 @@
+// A-SM1 Research Module
+// Adds life support recycling and some extra EC for convenient command of dark side transit
+
+@PART[Acamar_Lab_1]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 4
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+
+    // extra EC for convenient command of station during dark side transit
+    @RESOURCE[ElectricCharge]
+    {
+      @amount += 8000
+      @maxAmount += 8000
+    }
+
+    MODULE
+  	{
+  		name = ModuleLifeSupportRecycler
+  		CrewCapacity = 6
+  		RecyclePercent = .80
+  		ConverterName = Life Support
+  		tag = Life Support
+  		StartActionName = Start Life Support
+  		StopActionName = Stop Life Support
+
+  		INPUT_RESOURCE
+  		{
+  			ResourceName = ElectricCharge
+  			Ratio = 4.7
+  		}
+  	}
+
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Acamar_Lab_2.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Acamar_Lab_2.cfg
@@ -1,0 +1,59 @@
+// A-SM2 Research Module
+// Adds life support recycling and some extra EC for convenient command of dark side transit
+
+@PART[Acamar_Lab_2]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 4
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+
+    // extra EC for convenient command of station during dark side transit
+    @RESOURCE[ElectricCharge]
+    {
+      @amount += 4000
+      @maxAmount += 4000
+    }
+
+    MODULE
+  	{
+  		name = ModuleLifeSupportRecycler
+  		CrewCapacity = 4
+  		RecyclePercent = .80
+  		ConverterName = Life Support
+  		tag = Life Support
+  		StartActionName = Start Life Support
+  		StopActionName = Stop Life Support
+
+  		INPUT_RESOURCE
+  		{
+  			ResourceName = ElectricCharge
+  			Ratio = 3.8
+  		}
+  	}
+
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Alniyat_Crew_2_1.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Alniyat_Crew_2_1.cfg
@@ -1,0 +1,48 @@
+//A-B10 Crewed Block
+//Reccomend for MIR Kristall, Kvant II, Priroda, Spektre
+
+@PART[Alniyat_Crew_2_1]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 12
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+
+    RESOURCE
+    {
+        name = Supplies
+        amount = 1500
+        maxAmount = 1500
+    }
+
+    RESOURCE
+    {
+        name = Mulch
+        amount = 0
+        maxAmount = 30
+    }
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Alniyat_Crew_2_2.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Alniyat_Crew_2_2.cfg
@@ -1,0 +1,48 @@
+//A-B12 Crewed Block
+//Reccomend for TKS resupply vehicle and MIR Zarya, contains more supplies than A-B10 block
+
+@PART[Alniyat_Crew_2_2]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 12
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+
+    RESOURCE
+    {
+        name = Supplies
+        amount = 3000
+        maxAmount = 3000
+    }
+
+    RESOURCE
+    {
+        name = Mulch
+        amount = 0
+        maxAmount = 30
+    }
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Alniyat_Various.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Alniyat_Various.cfg
@@ -1,0 +1,34 @@
+//A-H12 Crewed Block
+
+@PART[Alniyat_Habitation_1|Alniyat_Habitation_2_1|Alniyat_Habitation_2_2|Alniyat_Crew_1|Alniyat_Crew_3_1|Alniyat_Crew_3_2|Alniyat_Crew_4]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 6
+        @BaseKerbalMonths *= #$CrewCapacity$
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Eridani_Crew_1.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Eridani_Crew_1.cfg
@@ -1,0 +1,32 @@
+//E-27KA Crew Module
+@PART[Eridani_Crew_1]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 12
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Eridani_Crew_2.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Eridani_Crew_2.cfg
@@ -1,0 +1,46 @@
+//E-27KB Crew Module
+@PART[Eridani_Crew_2]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 12
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+
+    RESOURCE
+    {
+        name = Supplies
+        amount = 1500
+        maxAmount = 1500
+    }
+
+    RESOURCE
+    {
+        name = Mulch
+        amount = 0
+        maxAmount = 30
+    }
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Hamal_Habitation_1.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Hamal_Habitation_1.cfg
@@ -1,0 +1,21 @@
+// H-FS1 Forward Section for Progress resupply craft
+@PART[Hamal_Habitation_1]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+    RESOURCE
+    {
+        name = Supplies
+        amount = 1500
+        maxAmount = 1500
+    }
+
+    RESOURCE
+    {
+        name = Mulch
+        amount = 0
+        maxAmount = 10
+    }
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Tantares_Habitation_1.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Tantares_Habitation_1.cfg
@@ -1,0 +1,21 @@
+//T-OM1B Orbital Module for Soyuz
+@PART[Tantares_Habitation_1]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+    RESOURCE
+    {
+        name = Supplies
+        amount = 375
+        maxAmount = 375
+    }
+
+    RESOURCE
+    {
+        name = Mulch
+        amount = 0
+        maxAmount = 10
+    }
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Tantares_Habitation_2_and_Orbital_2.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Tantares_Habitation_2_and_Orbital_2.cfg
@@ -1,0 +1,46 @@
+//T-SZ1B Habitation Section and T-SZ1 Habitation Section for Soyuz A
+@PART[Tantares_Habitation_2|Tantares_Orbital_2]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 0.5
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+
+    RESOURCE
+    {
+        name = Supplies
+        amount = 750
+        maxAmount = 750
+    }
+
+    RESOURCE
+    {
+        name = Mulch
+        amount = 0
+        maxAmount = 30
+    }
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Tantares_Libra_Crew_1.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Tantares_Libra_Crew_1.cfg
@@ -1,0 +1,21 @@
+// L-K15 'Луна' Lander Can
+@PART[Tantares_Libra_Crew_1]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+    RESOURCE
+    {
+        name = Supplies
+        amount = 75
+        maxAmount = 75
+    }
+
+    RESOURCE
+    {
+        name = Mulch
+        amount = 0
+        maxAmount = 10
+    }
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Tantares_Orbital_1.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Tantares_Orbital_1.cfg
@@ -1,0 +1,21 @@
+//T-OM1 Orbital Module for Soyuz
+@PART[Tantares_Orbital_1]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+    RESOURCE
+    {
+        name = Supplies
+        amount = 230
+        maxAmount = 230
+    }
+
+    RESOURCE
+    {
+        name = Mulch
+        amount = 0
+        maxAmount = 10
+    }
+}

--- a/GameData/Tantares/Patches/USI_LifeSupport/Vega_Habitation.cfg
+++ b/GameData/Tantares/Patches/USI_LifeSupport/Vega_Habitation.cfg
@@ -1,0 +1,32 @@
+// V-SA7 Crewed Block for Salyut
+@PART[Vega_Habitation_1]:NEEDS[USILifeSupport]:AFTER[USILifeSupport]
+{
+    MODULE
+    {
+        name = ModuleLifeSupport
+    }
+
+    MODULE
+    {
+        name = ModuleHabitation
+        CrewCapacity = #$../CrewCapacity$
+        BaseKerbalMonths = 12
+
+        BaseHabMultiplier = 0
+        ConverterName = Habitat
+        StartActionName = Start Habitat
+        StopActionName = Stop Habitat
+
+        INPUT_RESOURCE
+        {
+            ResourceName = ElectricCharge
+            Ratio = 0.05
+            @Ratio *= #$../CrewCapacity$
+        }
+    }
+
+    MODULE
+  	{
+  		name = USI_ModuleFieldRepair
+  	}
+}


### PR DESCRIPTION
Alternative pull request for USI Life Support which tries to add supplies and habitation in a way that is proportional to the parts actual use. Keeping in mind USI is a more gamified life support mod, usefulness in a stock scale solar system takes precedence over absolute accuracy.

- Adds supplies to selected station parts
- Adds habitation to all station parts
- No supplies for soyuz return capsule
- Supplies in soyuz orbital capsule
- supplies and hab in Soyuz-A orbital modules
- Supplies for progress orbital module
- Supplies in lander
- recycler in science labs