### PR TITLE
System Heat compatibility

### DIFF
--- a/GameData/Tantares/Patches/SystemHeat/SH_Radiators.cfg
+++ b/GameData/Tantares/Patches/SystemHeat/SH_Radiators.cfg
@@ -1,0 +1,163 @@
+@PART[aquila_active_radiator_srf_1]:NEEDS[SystemHeat]
+{
+  MODULE
+  {
+    name = ModuleSystemHeat
+    volume = 0.02
+    moduleID = default
+    iconName = Icon_Radiator
+    ignoreTemperature = true
+  }
+
+  @MODULE[ModuleActiveRadiator]
+  {
+    @name = ModuleSystemHeatRadiator
+    moduleID = radiator
+    // ModuleSystemHeat instance to link to
+    systemHeatModuleID = default
+    scalarModuleID = heat
+    maxTempAnimation = 500
+
+    // option: use physical or deterministic temperatures
+    // DOES NOT WORK YET
+    // Use emissivity to directly model temp
+    usePhysicalTemperatureModeling = false
+    // maximum temperature system can work at
+    maxRadiatorTemperature = 350
+    // emissivity
+    emissivity = 0.9
+
+    // option: use deterministic temperatures
+    // Power radiated per temperature
+    temperatureCurve
+    {
+      key = 0 0
+      key = 400 2.5
+    }
+    // area for convection
+    convectiveArea = 0.15
+  }
+}
+
+@PART[aquila_active_radiator_srf_2]:NEEDS[SystemHeat]
+{
+  MODULE
+  {
+    name = ModuleSystemHeat
+    volume = 0.04
+    moduleID = default
+    iconName = Icon_Radiator
+    ignoreTemperature = true
+  }
+
+  @MODULE[ModuleActiveRadiator]
+  {
+    @name = ModuleSystemHeatRadiator
+    moduleID = radiator
+    // ModuleSystemHeat instance to link to
+    systemHeatModuleID = default
+    scalarModuleID = heat
+    maxTempAnimation = 500
+
+    // option: use physical or deterministic temperatures
+    // DOES NOT WORK YET
+    // Use emissivity to directly model temp
+    usePhysicalTemperatureModeling = false
+    // maximum temperature system can work at
+    maxRadiatorTemperature = 350
+    // emissivity
+    emissivity = 0.9
+
+    // option: use deterministic temperatures
+    // Power radiated per temperature
+    temperatureCurve
+    {
+      key = 0 0
+      key = 400 5
+    }
+    // area for convection
+    convectiveArea = 0.3
+  }
+}
+
+@PART[aquila_radiator_fuel_tank_single_srf_2]:NEEDS[SystemHeat]
+{
+  MODULE
+  {
+    name = ModuleSystemHeat
+    volume = 0.02
+    moduleID = default
+    iconName = Icon_Radiator
+    ignoreTemperature = true
+  }
+
+  @MODULE[ModuleActiveRadiator]
+  {
+    @name = ModuleSystemHeatRadiator
+    moduleID = radiator
+    // ModuleSystemHeat instance to link to
+    systemHeatModuleID = default
+    scalarModuleID = heat
+    maxTempAnimation = 500
+
+    // option: use physical or deterministic temperatures
+    // DOES NOT WORK YET
+    // Use emissivity to directly model temp
+    usePhysicalTemperatureModeling = false
+    // maximum temperature system can work at
+    maxRadiatorTemperature = 350
+    // emissivity
+    emissivity = 0.9
+
+    // option: use deterministic temperatures
+    // Power radiated per temperature
+    temperatureCurve
+    {
+      key = 0 0
+      key = 400 2.2
+    }
+    // area for convection
+    convectiveArea = 0.15
+  }
+}
+
+@PART[aquila_radiator_fuel_tank_double_srf_2]:NEEDS[SystemHeat]
+{
+  MODULE
+  {
+    name = ModuleSystemHeat
+    volume = 0.04
+    moduleID = default
+    iconName = Icon_Radiator
+    ignoreTemperature = true
+  }
+
+  @MODULE[ModuleActiveRadiator]
+  {
+    @name = ModuleSystemHeatRadiator
+    moduleID = radiator
+    // ModuleSystemHeat instance to link to
+    systemHeatModuleID = default
+    scalarModuleID = heat
+    maxTempAnimation = 500
+
+    // option: use physical or deterministic temperatures
+    // DOES NOT WORK YET
+    // Use emissivity to directly model temp
+    usePhysicalTemperatureModeling = false
+    // maximum temperature system can work at
+    maxRadiatorTemperature = 350
+    // emissivity
+    emissivity = 0.9
+
+    // option: use deterministic temperatures
+    // Power radiated per temperature
+    temperatureCurve
+    {
+      key = 0 0
+      key = 400 4.4
+    }
+    // area for convection
+    convectiveArea = 0.25
+  }
+}


### PR DESCRIPTION
Adds System Heat compatibility based on SH patches to stock radiators and estimating relative area. Rads will continue to function as core heat radiators as well.